### PR TITLE
[Feat] TypeScript support for Node.js v22.6.0+

### DIFF
--- a/lua/js-playground/init.lua
+++ b/lua/js-playground/init.lua
@@ -28,7 +28,7 @@ end
 
 local create_autocmds = function()
 	autocmd("BufModifiedSet", {
-		pattern = { "*.js", "*.mjs", "*.cjs" },
+		pattern = { "*.js", "*.mjs", "*.cjs", "*.ts" },
 		desc = "Update playground on file write if playground is open",
 		group = vim.api.nvim_create_augroup("JSPlaygroundUpdater", { clear = false }),
 		callback = function()


### PR DESCRIPTION
Hi! First off, thank you for this amazing plugin, I’ve been using it for a while and it’s been working flawlessly.

This PR adds support for Typescript files natively in the playground, now that Node.js since v22.6.0 supports Typescript out of the box. I've also included version checks to ensure compatibility, as native Typescript execution only works with Node.js >= 22.6.0.

**Changes:**
- Added support for native Typescript execution via Node.js.
- Implemented validation to ensure this feature is only enabled on Node.js versions ≥ 22.6.0.

  - Reference: [Node.js native Typescript support](https://nodejs.org/en/learn/typescript/run-natively)